### PR TITLE
Revise data model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 livehtml:
-	$(shell which python) $(shell which sphinx-autobuild) -b html $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
+	$(shell which python) $(shell which sphinx-autobuild) -H 0.0.0.0 -b html $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
 
 .PHONY: help Makefile
 

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -12,300 +12,81 @@ add semantic color to these. It is a work in progress and likely to be
 incomplete and/or wrong.
 
 
-Data Model Breakdown
+Data Model Resources
 --------------------
 
-What is a Smart Contract?
-`````````````````````````
-
-This data model distinguishes between |ContractTypes| and |ContractInstances|:
+Bytecode
+````````
 
 .. uml::
 
+   !define SHOW_BYTECODE
    !include uml/macros.iuml
 
-   object(ContractInstance) {
-    + address : Address
-    + network : Network
-    + transactionHash : TransactionHash
-    + constructorArgs : Array<Value>
-    + contractType : ContractType
-    + callBytecode : Bytecode
-    + linkValues : Set<LinkValue>
-   }
+Source
+``````
 
-   object(ContractType) {
-    + name : String
-    + abi : ABI
-    + compilation : Compilation
-    + createBytecode : Bytecode
-   }
+.. uml::
 
-   object(Network) {
-    + name : String
-    + networkId : NetworkID
-   }
-
-   object(Compilation) {
-    + compiler : Compiler
-    + sources : Sources
-    + contractTypes: ContractTypes
-   }
-
-   object(Bytecode) {
-    + bytes: Array<Byte>
-    + instructions: Array<Instruction>
-    + sourceMap : SourceMap
-    + linkReferences : Set<LinkReference>
-   }
-
-   object(LinkValue) {
-    + linkReference : LinkReference
-    + value : Bytes
-   }
-
-   ContractInstance o-- "1" ContractType
-   ContractInstance *-- "1" Bytecode
-   ContractInstance *-- "n" LinkValue
-   ContractInstance o-right- "1" Network
-
-   ContractType *-- "1" Bytecode
-   ContractType o-- "0..1" Compilation
-
-A contract instance:
-
-* instantiates a single contract type (``contractType``).
-* is located at a particular network address (``address``, ``network``).
-* was deployed via a specific transaction (``transactionHash``).
-* contains runtime bytecode (``callBytecode``).
-* may contain known semantic information about compile-time and run-time
-  parameters (``linkValues``, ``constructorArgs``).
+  !define SHOW_SOURCE
+  !include uml/macros.iuml
 
 
-A contract type:
+Contract
+````````
 
-* has a name (``name``)
-* specifies a public external interface (``abi``)
-* contains bytecode for deployment (``createBytecode``)
-* may have known compilation information (``compilation``)
+.. uml::
 
-Contract Bytecode
+  !define SHOW_CONTRACT
+  !include uml/macros.iuml
+
+Compilation
+```````````
+
+.. uml::
+
+  !define SHOW_COMPILATION
+  !include uml/macros.iuml
+
+Source Map
+``````````
+
+.. uml::
+
+  !define SHOW_SOURCE_MAP
+  !include uml/macros.iuml
+
+Contract Instance
 `````````````````
 
-Bytecode is represented by an object that contains:
+.. uml::
 
-* An unlinked bytes array (``bytes``)
-* A list of any known link references (``linkReferences``)
-* Possibly a mapping to known source ranges (``sourceMap``)
-* An array of instruction objects containing information derived from the bytecode and sourcemap (``instructions``)
+  !define SHOW_INSTANCE
+  !include uml/macros.iuml
 
-Each link reference is represented by an object that specifies:
-
-* The length of the link in number of bytes (``length``)
-* The starting byte offsets for all corresponding gaps in the bytecode
-  (``offsets``)
+Contract Interface
+``````````````````
 
 .. uml::
 
-   !include uml/macros.iuml
+  !define SHOW_INTERFACE
+  !include uml/macros.iuml
 
-   object(Bytecode) {
-    + bytes: Array<Byte>
-    + sourceMap : SourceMap
-    + instructions: Array<Instruction>
-    + linkReferences : Set<LinkReference>
-   }
-
-   object(LinkReference) {
-    + offsets : Array<ByteOffset>
-    + length : Integer
-   }
-
-   object(SourceMap) {
-    + ranges : Map<ByteOffset => SourceRange>
-    + sources: Sources
-   }
-
-   object(Instruction) {
-    + programCounter: String
-    + opcode: Integer
-    + pushData: String
-    + sourceRanges: String
-    + meta: Object
-   }
-
-  object(Meta) {
-    + cost: Integer
-    + pops: Integer
-    + pushes: Integer
-    + dynamic: Integer
-   }   
-
-   Bytecode *-- "n" Instruction
-   Instruction *-- "1" Meta
-   Bytecode *-- "n" LinkReference
-   Bytecode *-- "0..1" SourceMap
-
-Contract Sourcecode
-```````````````````
-
-Sources are compiled in ordered groupings of individual source files.
-
-Compilation outputs one or more |ContractTypes| from a given list of sources.
+Contract Constructor
+````````````````````
 
 .. uml::
 
-   !include uml/macros.iuml
+  !define SHOW_CONSTRUCTOR
+  !include uml/macros.iuml
 
-   object(Compilation) {
-    + compiler : Compiler
-    + sources : Sources
-    + contractTypes: ContractTypes
-   }
-
-   collection(ContractTypes) {
-    + contractTypes : Set<ContractType>
-   }
-
-   object(Compiler) {
-    + name : String
-    + version : String
-    + settings : Object
-   }
-
-   object(Source) {
-    + contents : String
-    + sourcePath : String
-    + ast : AST
-   }
-
-   collection(Sources) {
-    + sources : Map<FileIndex => Source>
-   }
-
-   Compilation *-left- "n" ContractTypes
-
-   Compilation *-down- "1" Compiler
-   Compilation *-right- "1" Sources
-
-   Sources *-- "n" Source
-
-Each source:
-
-* contains human-readable code (``contents``)
-* may be found on disk somewhere (``sourcePath``)
-* can be parsed as an abstract syntax tree (``ast``)
-
-Source Mapping
-``````````````
-
-As part of compilation, bytecode can reference underlying source ranges by way
-of |SourceMaps|.
-
-.. uml::
-
-   !include uml/macros.iuml
-
-   object(Bytecode) {
-    + bytes: Array<Byte>
-    + sourceMap : SourceMap
-    + instructions: Array<Instruction>
-    + linkReferences : Set<LinkReference>
-   }
-
-   object(Instruction) {
-    + programCounter: String
-    + opcode: Integer
-    + pushData: String
-    + sourceRanges: String
-    + meta: Object
-   }
-
-  object(Meta) {
-    + cost: Integer
-    + pops: Integer
-    + pushes: Integer
-    + dynamic: Integer
-   }   
-
-   object(Source) {
-    + contents : String
-    + sourcePath : String
-    + ast : AST
-   }
-
-   collection(Sources) {
-    + sources : Map<FileIndex => Source>
-   }
-
-   object(SourceMap) {
-    + ranges : Map<ByteOffset => SourceRange>
-    + sources: Sources
-   }
-
-   object(SourceRange) {
-    + source : Source
-    + start : ByteOffset
-    + length : Length
-    + meta : Object
-   }
-
-   Bytecode *-- "1" SourceMap
-   Bytecode *-- "n" Instruction
-   Instruction *-- "1" Meta
-   SourceMap o-left- "1" Sources
-   SourceMap *-- "n" SourceRange
-   SourceRange o-left- "1" Source
-
-   Sources *-- "n" Source
-
-
-Linking
+Network
 ```````
 
-Bytecode may contain gaps to be filled in. These gaps are identified via
-|LinkReferences|. Corresponding |LinkValues| are contained within
-|ContractInstances|.
-
-
 .. uml::
 
-   !include uml/macros.iuml
-
-   object(ContractInstance) {
-    + address : Address
-    + network : Network
-    + transactionHash : TransactionHash
-    + constructorArgs : Array<Value>
-    + contractType : ContractType
-    + callBytecode : Bytecode
-    + linkValues : Set<LinkValue>
-   }
-
-   object(Bytecode) {
-    + bytes: Array<Byte>
-    + sourceMap : SourceMap
-    + instructions: Array<Instruction>
-    + linkReferences : Set<LinkReference>
-   }
-
-   object(LinkValue) {
-    + linkReference : LinkReference
-    + value : Bytes
-   }
-
-   object(LinkReference) {
-    + offsets : Array<ByteOffset>
-    + length : Integer
-   }
-
-
-   ContractInstance *-- "1" Bytecode
-   ContractInstance *-- "n" LinkValue
-
-   LinkReference "n" --* Bytecode
-
-   LinkValue ..> "1" LinkReference
+  !define SHOW_NETWORK
+  !include uml/macros.iuml
 
 
 Combined Data Model
@@ -313,171 +94,17 @@ Combined Data Model
 
 .. uml::
 
-   !include uml/macros.iuml
+   !define SHOW_BYTECODE
+   !define SHOW_COMPILATION
+   !define SHOW_SOURCE
+   !define SHOW_CONTRACT
+   !define SHOW_INSTANCE
+   !define SHOW_TYPE
+   !define SHOW_ABI
 
-   object(ContractInstance) {
-    + address : Address
-    + network : Network
-    + transactionHash : TransactionHash
-    + constructorArgs : Array<Value>
-    + contractType : ContractType
-    + callBytecode : Bytecode
-    + linkValues : Set<LinkValue>
-   }
-
-   object(ContractType) {
-    + name : String
-    + abi : ABI
-    + compilation : Compilation
-    + createBytecode : Bytecode
-   }
-
-   collection(ContractTypes) {
-    + contractTypes : Set<ContractType>
-   }
-
-   object(Source) {
-    + contents : String
-    + sourcePath : String
-    + ast : AST
-   }
-
-   collection(Sources) {
-    + sources : Map<FileIndex => Source>
-   }
-
-   object(Network) {
-    + name : String
-    + networkId : NetworkID
-   }
-
-   object(Compilation) {
-    + compiler : Compiler
-    + sources : Sources
-    + contractTypes: ContractTypes
-   }
-
-   object(Compiler) {
-    + name : String
-    + version : String
-    + settings : Object
-   }
-
-   object(Bytecode) {
-    + bytes: Array<Byte>
-    + sourceMap : SourceMap
-    + instructions: Array<Instruction>
-    + linkReferences : Set<LinkReference>
-   }
-
-   object(Instruction) {
-    + programCounter: String
-    + opcode: Integer
-    + pushData: String
-    + sourceRanges: String
-    + meta: Object
-   }
-
-  object(Meta) {
-    + cost: Integer
-    + pops: Integer
-    + pushes: Integer
-    + dynamic: Integer
-   }   
-
-   object(SourceMap) {
-    + sourceMap : Map<ByteOffset => SourceRange>
-    + sources: Sources
-   }
-
-   object(SourceRange) {
-    + source : Source
-    + start : ByteOffset
-    + length : Length
-    + meta : Object
-   }
-
-   object(LinkValue) {
-    + linkReference : LinkReference
-    + value : Bytes
-   }
-
-   object(LinkReference) {
-    + offsets : Array<ByteOffset>
-    + length : Integer
-   }
-
-
-   ContractInstance o-- "1" ContractType
-   ContractInstance *-- "1" Bytecode
-   ContractInstance *-- "n" LinkValue
-   ContractInstance o-right- "1" Network
-
-   ContractType "n" --* ContractTypes
-   ContractType *-- "1" Bytecode
-   ContractType o-- "0..1" Compilation
-
-   ContractTypes "n" --* Compilation
-
-   Compilation *-down- "1" Compiler
-   Compilation *-right- "1" Sources
-
-   Sources *-- "n" Source
-
-   Bytecode *-- "0..1" SourceMap
-   Bytecode *-- "n" Instruction
-   Instruction *-- "1" Meta
-   
-   SourceMap o-left- "1" Sources
-   SourceMap *-- "n" SourceRange
-   SourceRange o-left- "1" Source
-
-   LinkReference "n" --* Bytecode
-
-   LinkValue ..> "1" LinkReference
-
-Legend for Section Diagrams
----------------------------
-
-.. uml::
+   !define SHOW_AST
+   !define SHOW_INSTRUCTION
+   !define SHOW_SOURCE_MAP
+   !define SHOW_CONSTRUCTOR
 
    !include uml/macros.iuml
-
-   object(A) {
-   }
-   object(B) {
-   }
-   object(D) {
-   }
-   collection(C) {
-   }
-
-   A *-- "0..1" B
-
-   B o-- "n" D
-
-   A *-- "1" C
-
-   C *-- "n" D
-
-   A "1" <.. D
-
-In this example: **A**, **B**, **C**, and **D** are named resource types in
-the data model.
-
-Resources of these types are related as follows.
-
-   * Each *[resource of type]* **A** optionally owns a single *[resource of type]* **B**
-
-   * Each **B** refers to any whole number of **D**\ s
-
-   * Each **A** owns a single collection **C**
-
-   * Each **C** owns a whole number of **D**\ s
-
-   * Each **D** relates to a single **A**
-
-Generally, a given resource can have only one owner (or zero). Resources can
-refer to objects owned by another.
-
-

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -15,70 +15,44 @@ incomplete and/or wrong.
 Data Model Resources
 --------------------
 
-Bytecode
-````````
-
-.. uml::
-
-   !define SHOW_BYTECODE
-   !include uml/macros.iuml
-
-Source
-``````
-
-.. uml::
-
-  !define SHOW_SOURCE
-  !include uml/macros.iuml
-
-
-Contract
-````````
+Contracts, Constructors, and Instances
+```````````````````````````````````````
 
 .. uml::
 
   !define SHOW_CONTRACT
-  !include uml/macros.iuml
-
-Compilation
-```````````
-
-.. uml::
-
-  !define SHOW_COMPILATION
-  !include uml/macros.iuml
-
-Source Map
-``````````
-
-.. uml::
-
-  !define SHOW_SOURCE_MAP
-  !include uml/macros.iuml
-
-Contract Instance
-`````````````````
-
-.. uml::
-
   !define SHOW_INSTANCE
+  !define SHOW_CONSTRUCTOR
+  !define SHOW_BYTECODE
+  !define SHOW_INTERFACE
+  !define SHOW_SOURCE_CONTRACT
+  !define SHOW_NETWORK
+
   !include uml/macros.iuml
 
-Contract Interface
-``````````````````
+Sources, Bytecodes, and Compilations
+````````````````````````````````````
+
+.. uml::
+
+  !define SHOW_BYTECODE
+  !define SHOW_SOURCE
+  !define SHOW_COMPILATION
+  !define SHOW_SOURCE_MAP
+
+  !include uml/macros.iuml
+
+
+Contract Interfaces
+```````````````````
 
 .. uml::
 
   !define SHOW_INTERFACE
+  !define SHOW_INTERFACE_INTERNAL
+
   !include uml/macros.iuml
 
-Contract Constructor
-````````````````````
-
-.. uml::
-
-  !define SHOW_CONSTRUCTOR
-  !include uml/macros.iuml
 
 Network
 ```````
@@ -86,6 +60,8 @@ Network
 .. uml::
 
   !define SHOW_NETWORK
+  !define SHOW_NETWORK_INTERNAL
+
   !include uml/macros.iuml
 
 
@@ -101,12 +77,13 @@ Combined Data Model
 .. uml::
 
    !define SHOW_NETWORK
+   !define SHOW_NETWORK_INTERNAL
    !define SHOW_BYTECODE
    !define SHOW_COMPILATION
    !define SHOW_SOURCE
    !define SHOW_CONTRACT
+   !define SHOW_INTERFACE
    !define SHOW_INSTANCE
-   !define SHOW_TYPE
    !define SHOW_ABI
    !define SHOW_AST
    !define SHOW_INSTRUCTION

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -20,13 +20,21 @@ Contracts, Constructors, and Instances
 
 .. uml::
 
+  scale 0.75
+
   !define SHOW_CONTRACT
   !define SHOW_INSTANCE
   !define SHOW_CONSTRUCTOR
-  !define SHOW_BYTECODE
   !define SHOW_INTERFACE
-  !define SHOW_SOURCE_CONTRACT
+
+  !define SHOW_COMPILATION
+  !define EXTERN_COMPILATION
+
+  !define SHOW_BYTECODE
+  !define EXTERN_BYTECODE
+
   !define SHOW_NETWORK
+  !define EXTERN_NETWORK
 
   !include uml/macros.iuml
 
@@ -35,9 +43,15 @@ Sources, Bytecodes, and Compilations
 
 .. uml::
 
+  scale 0.75
+
+  !define SHOW_CONTRACT
+  !define EXTERN_CONTRACT
+
   !define SHOW_BYTECODE
   !define SHOW_SOURCE
   !define SHOW_COMPILATION
+  !define SHOW_COMPILER
   !define SHOW_SOURCE_MAP
 
   !include uml/macros.iuml
@@ -47,6 +61,8 @@ Contract Interfaces
 ```````````````````
 
 .. uml::
+
+  scale 0.75
 
   !define SHOW_INTERFACE
   !define SHOW_INTERFACE_INTERNAL
@@ -58,6 +74,8 @@ Network
 ```````
 
 .. uml::
+
+  scale 0.75
 
   !define SHOW_NETWORK
   !define SHOW_NETWORK_INTERNAL
@@ -76,11 +94,18 @@ Combined Data Model
 
 .. uml::
 
+   scale 0.75
+
    !define SHOW_NETWORK
    !define SHOW_NETWORK_INTERNAL
+
    !define SHOW_BYTECODE
+
    !define SHOW_COMPILATION
+   !define SHOW_COMPILER
+
    !define SHOW_SOURCE
+
    !define SHOW_CONTRACT
    !define SHOW_INTERFACE
    !define SHOW_INSTANCE

--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -108,7 +108,6 @@ Combined Data Model
    !define SHOW_INSTANCE
    !define SHOW_TYPE
    !define SHOW_ABI
-
    !define SHOW_AST
    !define SHOW_INSTRUCTION
    !define SHOW_SOURCE_MAP

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -1,4 +1,275 @@
 !define directory(name) class name << (D,cyan) Directory >>
 !define file(name) class name << (F,turquoise) File >>
-!define object(name) class name << (O,orchid) Object >>
+
+!define object(name) class name << (O,lawngreen) Data Object >>
+!define resource(name) class name << (R,orchid) Resource >>
 !define collection(name) class name << (C,deeppink) Collection >>
+
+'
+' Resources
+'
+
+!ifdef SHOW_BYTECODE
+!define SHOW_LINK_REFERENCE
+
+resource(Bytecode) {
+  + bytes: Array<Byte>
+  + instructions: Array<Instruction>
+  + linkReferences : Set<LinkReference>
+}
+
+object(Instruction) {
+  + programCounter: String
+  + opcode: Integer
+  + pushData: String
+  + meta: InstructionMeta
+}
+
+object(InstructionMeta) {
+  + cost: Integer
+  + pops: Integer
+  + pushes: Integer
+  + dynamic: Integer
+}
+
+Instruction *-- "1" InstructionMeta
+Bytecode *-- "n" Instruction
+!endif
+
+!ifdef SHOW_SOURCE
+resource(Source) {
+  + contents : String
+  + sourcePath : String
+}
+!endif
+
+
+!ifdef SHOW_CONTRACT
+resource(Contract) {
+  + name : String
+  + source : Source
+}
+!endif
+
+!ifdef SHOW_COMPILATION
+resource(Compilation) {
+  + compiler : Compiler
+  + sources : Array<Maybe<Source>>
+}
+
+object(Compiler) {
+  + name : String
+  + version : String
+  + settings : Object
+}
+
+Compilation *-left- "1" Compiler
+!endif
+
+!ifdef SHOW_SOURCE_MAP
+resource(SourceMap) {
+  + rawSourceMap : String
+  + sources : Array<Maybe<Source>>
+  + bytecode : Bytecode
+}
+
+object(SourceRange) {
+  + source : Source
+  + start : ByteOffset
+  + length : Length
+  + meta : Object
+}
+
+SourceMap *-- "n" SourceRange
+!endif
+
+
+!ifdef SHOW_INSTANCE
+!define SHOW_LINK_VALUE
+!define SHOW_TYPE
+resource(ContractInstance) {
+  + address : Address
+  + network : Network
+  + transactionHash : TransactionHash
+  + constructorArgs : Array<Value>
+  + contractType : ContractType
+  + callBytecode : Bytecode
+  + linkValues : Set<LinkValue>
+}
+!endif
+
+!ifdef SHOW_INTERFACE
+resource(ContractInterface) {
+}
+!endif
+
+!ifdef SHOW_CONSTRUCTOR
+!define SHOW_LINK_VALUE
+!define SHOW_TYPE
+resource(ContractConstructor) {
+  + name : String
+  + compilation : Compilation
+  + createBytecode : Bytecode
+  + contractType : ContractType
+  + linkValues : Set<LinkValue>
+}
+!endif
+
+!ifdef SHOW_NETWORK
+resource(Network) {
+  + name : String
+  + networkId : NetworkID
+}
+!endif
+
+
+
+'
+' Shared Data Objects
+'
+
+!ifdef SHOW_LINK_VALUE
+!define SHOW_LINK_REFERENCE
+object(LinkValue) {
+  + linkReference : LinkReference
+  + value : Bytes
+}
+!endif
+
+!ifdef SHOW_LINK_REFERENCE
+object(LinkReference) {
+  + offsets : Array<ByteOffset>
+  + length : Integer
+}
+!endif
+
+!ifdef SHOW_TYPE
+object(ContractType) {
+  + contract : Contract
+  + abi : ABI
+  + compilation : Compilation
+}
+!endif
+
+
+!ifdef SHOW_ABI
+object(ABI) {
+  + json : String
+}
+!endif
+
+!ifdef SHOW_AST
+object(AST) {
+  + json : String
+}
+!endif
+
+'
+' Relations
+'
+
+!ifdef SHOW_BYTECODE && SHOW_LINK_REFERENCE
+Bytecode *-- "n" LinkReference
+!endif
+
+!ifdef SHOW_TYPE && SHOW_CONTRACT
+ContractType o-- "1" Contract
+!endif
+
+!ifdef SHOW_TYPE && SHOW_COMPILATION
+ContractType o-- "1" Compilation
+!endif
+
+!ifdef SHOW_TYPE && SHOW_ABI
+ContractType o-- ABI
+!endif
+
+!ifdef SHOW_CONTRACT && SHOW_SOURCE
+Contract o-- "1" Source
+!endif
+
+!ifdef SHOW_INSTANCE && SHOW_NETWORK
+ContractInstance o-left- "1" Network
+!endif
+
+!ifdef SHOW_INSTANCE && SHOW_BYTECODE
+ContractInstance o-- "1" Bytecode
+!endif
+
+!ifdef SHOW_INSTANCE && SHOW_TYPE
+ContractInstance *-- "1" ContractType
+!endif
+
+!ifdef SHOW_CONSTRUCTOR && SHOW_TYPE
+ContractConstructor *-- "1" ContractType
+!endif
+
+!ifdef SHOW_INSTANCE && SHOW_CONSTRUCTOR
+ContractInstance o-- "1" ContractConstructor
+!endif
+
+!ifdef SHOW_INSTANCE && SHOW_LINK_VALUE
+ContractInstance *-- "n" LinkValue
+!endif
+
+
+!ifdef SHOW_CONSTRUCTOR && SHOW_BYTECODE
+ContractConstructor o-- "1" Bytecode
+!endif
+
+!ifdef SHOW_CONSTRUCTOR && SHOW_COMPILATION
+ContractConstructor "n" o-- "0..1" Compilation
+!endif
+
+!ifdef SHOW_CONSTRUCTOR && SHOW_LINK_VALUE
+ContractConstructor *-right- "n" LinkValue
+!endif
+
+!ifdef SHOW_COMPILATION && SHOW_SOURCE
+Compilation o-- "n" Source
+!endif
+
+!ifdef SHOW_COMPILATION
+' compilation outputs
+
+!ifdef SHOW_CONTRACT
+Compilation ..|> Contract : <<effects>>
+!endif
+
+!ifdef SHOW_AST
+Compilation ..|> AST : <<effects>>
+!endif
+
+!ifdef SHOW_BYTECODE
+Compilation ..|> Bytecode : <<effects>>
+!endif
+
+
+!ifdef SHOW_SOURCE_MAP
+Compilation ..|> SourceMap : <<effects>>
+!endif
+
+!endif
+
+
+
+
+!ifdef SHOW_SOURCE && SHOW_SOURCE_MAP
+Source "n" --o SourceMap
+!endif
+
+!ifdef SHOW_SOURCE && SHOW_AST
+Source *-- "0..1" AST
+!endif
+
+!ifdef SHOW_SOURCE_MAP && SHOW_BYTECODE
+SourceMap .right.> "n" Instruction
+!endif
+
+!ifdef SHOW_SOURCE_MAP && SHOW_SOURCE
+Source "1" --o SourceRange
+!endif
+
+!ifdef SHOW_LINK_VALUE && SHOW_LINK_REFERENCE
+LinkValue ..> "1" LinkReference
+!endif

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -9,127 +9,133 @@
 ' Resources
 '
 
-!ifdef SHOW_BYTECODE
-!define SHOW_LINK_REFERENCE
-
-resource(Bytecode) {
-  + bytes: Array<Byte>
-  + instructions: Array<Instruction>
-  + linkReferences : Set<LinkReference>
-}
-
-object(Instruction) {
-  + programCounter: String
-  + opcode: Integer
-  + pushData: String
-  + meta: InstructionMeta
-}
-
-object(InstructionMeta) {
-  + cost: Integer
-  + pops: Integer
-  + pushes: Integer
-  + dynamic: Integer
-}
-
-Instruction *-- "1" InstructionMeta
-Bytecode *-- "n" Instruction
-!endif
-
-!ifdef SHOW_SOURCE
-resource(Source) {
-  + contents : String
-  + sourcePath : String
-}
-!endif
-
-
 !ifdef SHOW_CONTRACT
-resource(Contract) {
-  + name : String
-  + source : Source
-}
+  resource(Contract) {
+    + abi : ABI
+    + name : String
+  }
 !endif
-
-!ifdef SHOW_COMPILATION
-resource(Compilation) {
-  + compiler : Compiler
-  + sources : Array<Maybe<Source>>
-}
-
-object(Compiler) {
-  + name : String
-  + version : String
-  + settings : Object
-}
-
-Compilation *-left- "1" Compiler
-!endif
-
-!ifdef SHOW_SOURCE_MAP
-resource(SourceMap) {
-  + rawSourceMap : String
-  + sources : Array<Maybe<Source>>
-  + bytecode : Bytecode
-}
-
-object(SourceRange) {
-  + source : Source
-  + start : ByteOffset
-  + length : Length
-  + meta : Object
-}
-
-SourceMap *-- "n" SourceRange
-!endif
-
 
 !ifdef SHOW_INSTANCE
-!define SHOW_LINK_VALUE
-!define SHOW_TYPE
-resource(ContractInstance) {
-  + address : Address
-  + network : Network
-  + transactionHash : TransactionHash
-  + constructorArgs : Array<Value>
-  + contractType : ContractType
-  + callBytecode : Bytecode
-  + linkValues : Set<LinkValue>
-}
+  !define SHOW_LINK_VALUE
+  !define SHOW_INSTANCE_CREATION
+
+  resource(ContractInstance) {
+    + address : Address
+    + network : Network
+    + creation : ContractInstanceCreation
+    + contract : Contract
+    + callBytecode : LinkedBytecode
+    + linkValues : Set<LinkValue>
+  }
+
+  ContractInstance *-right- "0..1" ContractInstanceCreation
 !endif
 
 !ifdef SHOW_INTERFACE
-resource(ContractInterface) {
-}
+  resource(ContractInterface) {
+  }
 !endif
 
 !ifdef SHOW_CONSTRUCTOR
-!define SHOW_LINK_VALUE
-!define SHOW_TYPE
-resource(ContractConstructor) {
-  + name : String
-  + compilation : Compilation
-  + createBytecode : Bytecode
-  + contractType : ContractType
-  + linkValues : Set<LinkValue>
-}
+  !define SHOW_LINK_VALUE
+
+  resource(ContractConstructor) {
+    + name : String
+    + compilation : Compilation
+    + createBytecode : LinkedBytecode
+  }
 !endif
 
+
+!ifdef SHOW_BYTECODE
+  !define SHOW_LINK_REFERENCE
+
+  resource(Bytecode) {
+    + bytes: Array<Byte>
+    + instructions: Array<Instruction>
+    + linkReferences : Set<LinkReference>
+  }
+
+  object(Instruction) {
+    + programCounter: String
+    + opcode: Integer
+    + pushData: String
+    + meta: InstructionMeta
+  }
+
+  object(InstructionMeta) {
+    + cost: Integer
+    + pops: Integer
+    + pushes: Integer
+    + dynamic: Integer
+  }
+
+  Instruction *-- "1" InstructionMeta
+  Bytecode *-- "n" Instruction
+!endif
+
+!ifdef SHOW_SOURCE
+  resource(Source) {
+    + contents : String
+    + sourcePath : String
+  }
+!endif
+
+
+
+!ifdef SHOW_COMPILATION
+  !define SHOW_SOURCE_CONTRACT
+
+  resource(Compilation) {
+    + compiler : Compiler
+    + sources : Array<Maybe<Source>>
+  }
+
+  object(Compiler) {
+    + name : String
+    + version : String
+    + settings : Object
+  }
+
+  Compiler "1" --* Compilation
+  SourceContract "n" -right-* Compilation
+!endif
+
+!ifdef SHOW_SOURCE_MAP
+  resource(SourceMap) {
+    + rawSourceMap : String
+    + sources : Array<Maybe<Source>>
+    + bytecode : Bytecode
+  }
+
+  object(SourceRange) {
+    + source : Source
+    + start : ByteOffset
+    + length : Length
+    + meta : Object
+  }
+
+  SourceMap *-- "n" SourceRange
+!endif
+
+
+
 !ifdef SHOW_NETWORK
-resource(Network) {
-  + name : String
-  + networkId : NetworkID
-  + fork : Maybe<Network>
-  + historicBlock: Block
-}
+  resource(Network) {
+    + name : String
+    + networkId : NetworkID
+    + fork : Maybe<Network>
+    + historicBlock: Block
+  }
 
-object(Block) {
-  + height : Integer
-  + hash : BlockHash
-}
+  object(Block) {
+    + height : Integer
+    + hash : BlockHash
+  }
 
-Network o-- "0..1" Network : <<refines>>
-Network *-- "1" Block
+  Network o-- "0..1" Network : <<refines>>
+  Network *-right- "1" Block
 !endif
 
 
@@ -138,126 +144,137 @@ Network *-- "1" Block
 ' Shared Data Objects
 '
 
+!ifdef (SHOW_BYTECODE && SHOW_INSTANCE) || (SHOW_BYTECODE && SHOW_CONSTRUCTOR)
+  !define SHOW_LINKED_BYTECODE
+!endif
+
+!ifdef SHOW_LINKED_BYTECODE
+  object(LinkedBytecode) {
+    + bytecode : Bytecode
+    + linkValues : Set<LinkValue>
+  }
+!endif
+
+!ifdef SHOW_INSTANCE_CREATION
+  object(ContractInstanceCreation) {
+    + transactionHash : TransactionHash
+    + contractConstructor : ContractConstructor
+    + constructorArgs : Array<Value>
+  }
+!endif
+
 !ifdef SHOW_LINK_VALUE
-!define SHOW_LINK_REFERENCE
-object(LinkValue) {
-  + linkReference : LinkReference
-  + value : Bytes
-}
+  !define SHOW_LINK_REFERENCE
+  object(LinkValue) {
+    + linkReference : LinkReference
+    + value : Bytes
+  }
 !endif
 
 !ifdef SHOW_LINK_REFERENCE
-object(LinkReference) {
-  + offsets : Array<ByteOffset>
-  + length : Integer
-}
+  object(LinkReference) {
+    + offsets : Array<ByteOffset>
+    + length : Integer
+  }
 !endif
 
-!ifdef SHOW_TYPE
-object(ContractType) {
-  + contract : Contract
-  + abi : ABI
-  + compilation : Compilation
-}
+!ifdef SHOW_SOURCE_CONTRACT
+  object(SourceContract) {
+    + name : String
+    + compilation : Compilation
+  }
 !endif
-
 
 !ifdef SHOW_ABI
-object(ABI) {
-  + json : String
-}
+  object(ABI) {
+    + json : String
+  }
 !endif
 
 !ifdef SHOW_AST
-object(AST) {
-  + json : String
-}
+  object(AST) {
+    + json : String
+  }
 !endif
 
 '
 ' Relations
 '
 
+!ifdef SHOW_CONTRACT && SHOW_ABI
+  Contract *-left- "1" ABI
+!endif
+
+!ifdef SHOW_CONTRACT && SHOW_INSTANCE
+  ContractInstance "n" o-- "1" Contract
+!endif
+
+!ifdef SHOW_CONTRACT && SHOW_CONSTRUCTOR
+  ContractConstructor "1" o-- "1" Contract
+!endif
+
+!ifdef SHOW_CONTRACT && SHOW_SOURCE_CONTRACT
+  Contract o-- "0..1" SourceContract
+!endif
+
 !ifdef SHOW_BYTECODE && SHOW_LINK_REFERENCE
-Bytecode *-- "n" LinkReference
+  LinkReference "n" --* Bytecode
 !endif
 
-!ifdef SHOW_TYPE && SHOW_CONTRACT
-ContractType o-- "1" Contract
+!ifdef SHOW_LINKED_BYTECODE && SHOW_BYTECODE
+  LinkedBytecode o-- "1" Bytecode
 !endif
 
-!ifdef SHOW_TYPE && SHOW_COMPILATION
-ContractType o-- "1" Compilation
+!ifdef SHOW_LINKED_BYTECODE && SHOW_LINK_VALUE
+  LinkedBytecode *-- "n" LinkValue
 !endif
 
-!ifdef SHOW_TYPE && SHOW_ABI
-ContractType o-- ABI
-!endif
 
-!ifdef SHOW_CONTRACT && SHOW_SOURCE
-Contract o-- "1" Source
+!ifdef SHOW_SOURCE_CONTRACT && SHOW_SOURCE
+  SourceContract o-- "1" Source
 !endif
 
 !ifdef SHOW_INSTANCE && SHOW_NETWORK
-ContractInstance o-- "1" Network
+  Network "1" --o ContractInstance
 !endif
 
-!ifdef SHOW_INSTANCE && SHOW_BYTECODE
-ContractInstance o-- "1" Bytecode
+!ifdef SHOW_INSTANCE_CREATION && SHOW_CONSTRUCTOR
+  ContractInstanceCreation o-right- "1" ContractConstructor
 !endif
 
-!ifdef SHOW_INSTANCE && SHOW_TYPE
-ContractInstance *-- "1" ContractType
+!ifdef SHOW_INSTANCE && SHOW_LINKED_BYTECODE
+  ContractInstance *-- "1" LinkedBytecode
 !endif
 
-!ifdef SHOW_CONSTRUCTOR && SHOW_TYPE
-ContractConstructor *-- "1" ContractType
-!endif
-
-!ifdef SHOW_INSTANCE && SHOW_CONSTRUCTOR
-ContractInstance o-- "1" ContractConstructor
-!endif
-
-!ifdef SHOW_INSTANCE && SHOW_LINK_VALUE
-ContractInstance *-- "n" LinkValue
-!endif
-
-
-!ifdef SHOW_CONSTRUCTOR && SHOW_BYTECODE
-ContractConstructor o-- "1" Bytecode
-!endif
-
-!ifdef SHOW_CONSTRUCTOR && SHOW_COMPILATION
-ContractConstructor "n" o-- "0..1" Compilation
-!endif
-
-!ifdef SHOW_CONSTRUCTOR && SHOW_LINK_VALUE
-ContractConstructor *-right- "n" LinkValue
+!ifdef SHOW_CONSTRUCTOR && SHOW_LINKED_BYTECODE
+  ContractConstructor *-- "1" LinkedBytecode
 !endif
 
 !ifdef SHOW_COMPILATION && SHOW_SOURCE
-Compilation o-- "n" Source
+  Compilation o-- "n" Source
 !endif
 
 !ifdef SHOW_COMPILATION
-' compilation outputs
+  ' compilation outputs
 
-!ifdef SHOW_CONTRACT
-Compilation ..|> Contract : <<effects>>
-!endif
+  !ifdef SHOW_EFFECTS
+    !ifdef SHOW_CONTRACT
+    Compilation ..|> Contract : <<effects>>
+    !endif
 
-!ifdef SHOW_AST
-Compilation ..|> AST : <<effects>>
-!endif
+    !ifdef SHOW_AST
+    Compilation ..|> AST : <<effects>>
+    !endif
 
-!ifdef SHOW_BYTECODE
-Compilation ..|> Bytecode : <<effects>>
-!endif
+    !ifdef SHOW_BYTECODE
+    Compilation ..|> Bytecode : <<effects>>
+    !endif
 
 
-!ifdef SHOW_SOURCE_MAP
-Compilation ..|> SourceMap : <<effects>>
-!endif
+    !ifdef SHOW_SOURCE_MAP
+    Compilation ..|> SourceMap : <<effects>>
+    !endif
+  !endif
 
 !endif
 
@@ -265,21 +282,21 @@ Compilation ..|> SourceMap : <<effects>>
 
 
 !ifdef SHOW_SOURCE && SHOW_SOURCE_MAP
-Source "n" --o SourceMap
+  Source "n" --o SourceMap
 !endif
 
 !ifdef SHOW_SOURCE && SHOW_AST
-Source *-- "0..1" AST
+  Source *-- "0..1" AST
 !endif
 
 !ifdef SHOW_SOURCE_MAP && SHOW_BYTECODE
-SourceMap .right.> "n" Instruction
+  SourceMap .right.> "n" Instruction
 !endif
 
 !ifdef SHOW_SOURCE_MAP && SHOW_SOURCE
-Source "1" --o SourceRange
+  Source "1" --o SourceRange
 !endif
 
 !ifdef SHOW_LINK_VALUE && SHOW_LINK_REFERENCE
-LinkValue ..> "1" LinkReference
+  LinkValue ..> "1" LinkReference
 !endif

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -1,9 +1,17 @@
+skinparam defaultMonospacedFontName Andale Mono
+!define TBD [//to be completed <&warning>//]
 !define directory(name) class name << (D,cyan) Directory >>
 !define file(name) class name << (F,turquoise) File >>
+!define hashIdField(h1) - {field} <&key> ID //= hash(// ""h1"" //)//
+!define hashIdField(h1,h2) - {field} <&key> ID //= hash(// ""h1""//,// ""h2"" //)//
+!define hashIdField(h1,h2,h3) - {field} <&key> ID //= hash(// ""h1""//,// ""h2""//,// ""h3"" //)//
+!define UNKNOWN_ID - {field} <&key> ID = TBD
 
 !define object(name) class name << (O,lawngreen) Data Object >>
 !define enum(name) class name << (E,yellow) Enum >>
 !define resource(name) class name << (R,orchid) Resource >>
+!define extern(name) class name << (R,darkorange) External Resource >>
+!define externObject(name) class name << (O,khaki) External Object >>
 !define collection(name) class name << (C,deeppink) Collection >>
 
 '
@@ -11,12 +19,26 @@
 '
 
 !ifdef SHOW_CONTRACT
-  resource(Contract) {
-    + name : String
-    + abi : ABI
-    + interface : ContractInterface
-    + sourceContract : Maybe<SourceContract>
-  }
+  !ifdef EXTERN_CONTRACT
+    extern(Contract) {
+      + name: String
+      + abi: ABI
+      + {method} compilation: Maybe<Compilation>
+      + {method} sourceContract: Maybe<SourceContract>
+      + {method} interface: ContractInterface
+    }
+  !else
+    resource(Contract) {
+      + name: String
+      + abi: ABI
+      + {method} compilation: Maybe<Compilation>
+      + {method} sourceContract: Maybe<SourceContract>
+      + {method} interface: ContractInterface
+      ..
+      UNKNOWN_ID
+      - sourceContractId: TBD
+    }
+  !endif
 !endif
 
 !ifdef SHOW_INSTANCE
@@ -27,19 +49,24 @@
     + address : Address
     + network : Network
     + creation : Maybe<ContractInstanceCreation>
-    + contract : Maybe<Contract>
     + callBytecode : LinkedBytecode
+    + {method} contract : Maybe<Contract>
+    ..
+    UNKNOWN_ID
+    - contractId: ID
   }
 
-  ContractInstance *-right- "0..1" ContractInstanceCreation
+  ContractInstanceCreation "0..1" ---* ContractInstance
 !endif
 
 !ifdef SHOW_INTERFACE
   resource(ContractInterface) {
-    + constructor : Maybe<ConstructorInterface>
-    + fallback : Maybe<FallbackInterface>
-    + functions : Set<FunctionInterface>
-    + events : Set<EventInterface>
+    + constructor : Maybe<Constructor>
+    + fallback : Maybe<Fallback>
+    + functions : Set<Function>
+    + events : Set<Event>
+    ..
+    UNKNOWN_ID
   }
 
   ContractInterface o-- "n" ContractInterface
@@ -106,8 +133,11 @@
   !define SHOW_LINKED_BYTECODE
 
   resource(ContractConstructor) {
-    + contract : Maybe<Contract>
-    + createBytecode : LinkedBytecode
+    + createBytecode: LinkedBytecode
+    + {method} contract: Maybe<Contract>
+    ..
+    UNKNOWN_ID
+    - contractId: Maybe<ID>
   }
 !endif
 
@@ -115,11 +145,22 @@
 !ifdef SHOW_BYTECODE
   !define SHOW_LINK_REFERENCE
 
-  resource(Bytecode) {
-    + bytes: Array<Byte>
-    + instructions: Array<Instruction>
-    + linkReferences : Set<LinkReference>
-  }
+  !ifdef EXTERN_BYTECODE
+    extern(Bytecode) {
+      + bytes: Array<Byte>
+      + linkReferences : Set<LinkReference>
+      + {method} instructions: Array<Instruction>
+      ..
+    }
+  !else
+    resource(Bytecode) {
+      + bytes: Array<Byte>
+      + linkReferences : Set<LinkReference>
+      + {method} instructions: Array<Instruction>
+      ..
+      hashIdField(bytes)
+    }
+  !endif
 
   !ifdef SHOW_SOURCE_MAP || SHOW_BYTECODE_INTERNAL
     object(Instruction) {
@@ -136,16 +177,18 @@
       + dynamic: Integer
     }
 
-    Instruction *-- "1" InstructionMeta
-    Bytecode *-- "n" Instruction
+    Instruction *-right- "1" InstructionMeta
+    Instruction "n" --* Bytecode
   !endif
 !endif
 
 !ifdef SHOW_SOURCE
-  resource(Source) {
-    + contents : String
-    + sourcePath : String
-  }
+    resource(Source) {
+      + contents: String
+      + sourcePath: Maybe<String>
+      ..
+      hashIdField(contents,sourcePath)
+    }
 !endif
 
 
@@ -153,40 +196,59 @@
 !ifdef SHOW_COMPILATION
   !define SHOW_SOURCE_CONTRACT
 
-  resource(Compilation) {
-    + compiler : Compiler
-    + sources : Array<Maybe<Source>>
-    + contracts : Array<SourceContract>
-  }
+  !ifdef EXTERN_COMPILATION
+    extern(Compilation) {
+      + compiler : Compiler
+      + {method} sources : Array<Maybe<Source>>
+      + {method} contracts : Array<SourceContract>
+      ..
+    }
+  !else
+    resource(Compilation) {
+      + compiler : Compiler
+      + {method} sources : Array<Maybe<Source>>
+      + {method} contracts : Array<SourceContract>
+      ..
+      hashIdField(compiler,sourceIds)
+      - sourceIds: Array<Maybe<ID>>
+      - contractIds : Array<Maybe<ID>>
+    }
+  !endif
 
-  object(Compiler) {
-    + name : String
-    + version : String
-    + settings : Object
-  }
-
-  Compilation *-- "1" Compiler
   SourceContract "n" --* Compilation
 !endif
 
 !ifdef SHOW_NETWORK
-  resource(Network) {
-    + name : String
-    + networkId : NetworkID
-    + fork : Maybe<Network>
-    + historicBlock: Block
-  }
-
-
-  !ifdef SHOW_NETWORK_INTERNAL
-    object(Block) {
-      + height : Integer
-      + hash : BlockHash
+  !ifdef EXTERN_NETWORK
+    extern(Network) {
+      + name : String
+      + networkId : NetworkID
+      + historicBlock: Block
+      + {method} fork: Maybe<Network>
+      ..
     }
-
-    Network o-- "0..1" Network : <<refines>>
-    Network *-left- "1" Block
+  !else
+    resource(Network) {
+      + name : String
+      + networkId : NetworkID
+      + historicBlock: Block
+      + {method} fork: Maybe<Network>
+      ..
+      UNKNOWN_ID
+      - forkId: Maybe<ID>
+    }
   !endif
+
+
+    !ifdef SHOW_NETWORK_INTERNAL
+      object(Block) {
+        + height : Integer
+        + hash : BlockHash
+      }
+
+      Network o-- "0..1" Network : <<refines>>
+      Network *-left- "1" Block
+    !endif
 !endif
 
 
@@ -202,70 +264,107 @@
 !ifdef SHOW_LINKED_BYTECODE
   !define SHOW_LINK_VALUE
 
-  object(LinkedBytecode) {
-    + bytecode : Bytecode
-    + linkValues : Set<LinkValue>
+    object(LinkedBytecode) {
+      + bytecode : Bytecode
+      + linkValues : Set<LinkValue>
+    }
+!endif
+
+!ifdef SHOW_COMPILER
+  object(Compiler) {
+    + name : String
+    + version : String
+    + settings : Object
   }
+
 !endif
 
 !ifdef SHOW_INSTANCE_CREATION
-  object(ContractInstanceCreation) {
-    + transactionHash : TransactionHash
-    + constructor : ContractConstructor
-    + constructorArgs : Array<Value>
-  }
+    object(ContractInstanceCreation) {
+      + transactionHash: TransactionHash
+      + constructorArgs: Array<Value>
+      + {method} contractConstructor: ContractConstructor
+      ..
+      - contractConstructorId: ID
+    }
 !endif
 
 !ifdef SHOW_LINK_VALUE
   !define SHOW_LINK_REFERENCE
-  object(LinkValue) {
-    + linkReference : LinkReference
-    + value : Bytes
-  }
+    object(LinkValue) {
+      + value: Bytes
+      + {method} linkReference: LinkReference
+      ..
+      - _linkReference: TBD
+    }
 !endif
 
 !ifdef SHOW_LINK_REFERENCE
-  object(LinkReference) {
-    + offsets : Array<ByteOffset>
-    + length : Integer
-  }
+  !ifdef EXTERN_BYTECODE
+    externObject(LinkReference) {
+      + offsets: Array<ByteOffset>
+      + name: Maybe<String>
+      + length: Integer
+    }
+  !else
+    object(LinkReference) {
+      + offsets: Array<ByteOffset>
+      + name: Maybe<String>
+      + length: Integer
+    }
+  !endif
 !endif
 
 !ifdef SHOW_SOURCE_MAP
-  object(SourceMap) {
-    + rawSourceMap : String
-    + sources : Array<Maybe<Source>>
-    + bytecode : Bytecode
-  }
+    object(SourceMap) {
+      + {method} bytecode: Bytecode
+      + instructionSourceRanges(index: Integer): Maybe<SourceRange>
+      ..
+      - rawSourceMap: String
+      - bytecodeId: ID
+    }
 
-  object(SourceRange) {
-    + source : Source
-    + start : ByteOffset
-    + length : Length
-    + meta : Object
-  }
+    object(SourceRange) {
+      + start: ByteOffset
+      + length: Length
+      + meta: Object
+      + {method} source: Source
+      ..
+      - sourceId: ID
+    }
 
-  SourceMap *-- "n" SourceRange
+    SourceMap *-right- "n" SourceRange
 !endif
 
 
 !ifdef SHOW_SOURCE_CONTRACT
-  object(SourceContract) {
-    + name : String
-    + source : Source
-    + ast : AST
-  }
+  !ifdef EXTERN_COMPILATION
+    externObject(SourceContract) {
+      + name: String
+      + ast: AST
+      + {method} source: Source
+      ..
+    }
+  !else
+    object(SourceContract) {
+      + name: String
+      + ast: AST
+      + {method} source: Source
+      ..
+      - sourceId: ID
+    }
+  !endif
 !endif
 
 !ifdef SHOW_ABI
-  object(ABI) {
-    + json : String
-  }
+    object(ABI) {
+      + json: String
+    }
 !endif
 
 !ifdef SHOW_AST
   object(AST) {
-    + json : String
+    + json: String
   }
 !endif
 
@@ -278,31 +377,37 @@
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_INSTANCE
-  ContractInstance "n" o-- "0..1" Contract
+  ContractInstance "n" o--- "0..1" Contract
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_CONSTRUCTOR
-  ContractConstructor "1" o-- "0..1" Contract
+  ContractConstructor "1" o--- "0..1" Contract
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_INTERFACE
-  Contract o-- "1" ContractInterface
+  ContractInterface "1" ---o Contract
+
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_SOURCE_CONTRACT
-  Contract o-- "0..1" SourceContract
-!endif
-
-!ifdef SHOW_BYTECODE && SHOW_LINK_REFERENCE
-  LinkReference "n" --* Bytecode
+  Contract o-- "0..1" Compilation
+  Contract o.. "1" SourceContract
 !endif
 
 !ifdef SHOW_LINKED_BYTECODE && SHOW_BYTECODE
-  LinkedBytecode o-- "1" Bytecode
+  LinkedBytecode o---- "1" Bytecode
 !endif
 
 !ifdef SHOW_LINKED_BYTECODE && SHOW_LINK_VALUE
   LinkedBytecode *-- "n" LinkValue
+!endif
+
+!ifdef SHOW_BYTECODE && SHOW_LINK_REFERENCE
+  LinkReference "n" -* Bytecode
+!endif
+
+!ifdef SHOW_LINK_VALUE && SHOW_LINK_REFERENCE
+  LinkValue ....> "1" LinkReference
 !endif
 
 
@@ -311,11 +416,11 @@
 !endif
 
 !ifdef SHOW_INSTANCE && SHOW_NETWORK
-  Network "1" --o ContractInstance
+  Network "1" ---o ContractInstance
 !endif
 
 !ifdef SHOW_INSTANCE_CREATION && SHOW_CONSTRUCTOR
-  ContractInstanceCreation o-right- "1" ContractConstructor
+  ContractInstanceCreation o-- "1" ContractConstructor
 !endif
 
 !ifdef SHOW_INSTANCE && SHOW_LINKED_BYTECODE
@@ -326,32 +431,12 @@
   ContractConstructor *-- "1" LinkedBytecode
 !endif
 
-!ifdef SHOW_COMPILATION && SHOW_SOURCE
-  Compilation o-right- "n" Source
+!ifdef SHOW_COMPILATION && SHOW_COMPILER
+  Compilation *-left- "1" Compiler
 !endif
 
-!ifdef SHOW_COMPILATION
-  ' compilation outputs
-
-  !ifdef SHOW_EFFECTS
-    !ifdef SHOW_CONTRACT
-    Compilation ..|> Contract : <<effects>>
-    !endif
-
-    !ifdef SHOW_AST
-    Compilation ..|> AST : <<effects>>
-    !endif
-
-    !ifdef SHOW_BYTECODE
-    Compilation ..|> Bytecode : <<effects>>
-    !endif
-
-
-    !ifdef SHOW_SOURCE_MAP
-    Compilation ..|> SourceMap : <<effects>>
-    !endif
-  !endif
-
+!ifdef SHOW_COMPILATION && SHOW_SOURCE
+  Compilation o-right- "n" Source
 !endif
 
 
@@ -361,18 +446,15 @@
 
 
 !ifdef SHOW_SOURCE_CONTRACT && SHOW_AST
-  SourceContract *-right- "0..1" AST
+  SourceContract *-left- "0..1" AST
 !endif
 
 !ifdef SHOW_SOURCE_MAP && SHOW_BYTECODE
-  SourceMap o-right- "1" Bytecode
-  SourceRange o-right- "1" Instruction
+  SourceMap o---- "1" Bytecode
+  SourceRange o-- "1" Instruction
 !endif
 
 !ifdef SHOW_SOURCE_MAP && SHOW_SOURCE
   Source "1" --o SourceRange
 !endif
 
-!ifdef SHOW_LINK_VALUE && SHOW_LINK_REFERENCE
-  LinkValue ..> "1" LinkReference
-!endif

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -2,6 +2,7 @@
 !define file(name) class name << (F,turquoise) File >>
 
 !define object(name) class name << (O,lawngreen) Data Object >>
+!define enum(name) class name << (E,yellow) Enum >>
 !define resource(name) class name << (R,orchid) Resource >>
 !define collection(name) class name << (C,deeppink) Collection >>
 
@@ -11,22 +12,23 @@
 
 !ifdef SHOW_CONTRACT
   resource(Contract) {
-    + abi : ABI
     + name : String
+    + abi : ABI
+    + interface : ContractInterface
+    + sourceContract : Maybe<SourceContract>
   }
 !endif
 
 !ifdef SHOW_INSTANCE
-  !define SHOW_LINK_VALUE
   !define SHOW_INSTANCE_CREATION
+  !define SHOW_LINKED_BYTECODE
 
   resource(ContractInstance) {
     + address : Address
     + network : Network
-    + creation : ContractInstanceCreation
-    + contract : Contract
+    + creation : Maybe<ContractInstanceCreation>
+    + contract : Maybe<Contract>
     + callBytecode : LinkedBytecode
-    + linkValues : Set<LinkValue>
   }
 
   ContractInstance *-right- "0..1" ContractInstanceCreation
@@ -34,15 +36,77 @@
 
 !ifdef SHOW_INTERFACE
   resource(ContractInterface) {
+    + constructor : Maybe<ConstructorInterface>
+    + fallback : Maybe<FallbackInterface>
+    + functions : Set<FunctionInterface>
+    + events : Set<EventInterface>
   }
+
+  ContractInterface o-- "n" ContractInterface
+
+  !ifdef SHOW_INTERFACE_INTERNAL
+    object(ConstructorInterface) {
+      + inputs : Array<Parameter>
+      + stateMutability : StateMutability
+    }
+
+    object(FallbackInterface) {
+      + stateMutability : StateMutability
+    }
+
+    object(FunctionInterface) {
+      + name : String
+      + inputs : Array<Parameter>
+      + outputs : Array<Parameter>
+      + stateMutability : StateMutability
+    }
+
+    object(EventInterface) {
+      + name : String
+      + inputs : Array<EventParameter>
+      + anonymous : Boolean
+    }
+
+    ContractInterface *-- "0..1" ConstructorInterface
+    ContractInterface *-- "0..1" FallbackInterface
+    ContractInterface *-- "n" FunctionInterface
+    ContractInterface *-- "n" EventInterface
+
+    object(Parameter) {
+      + name : String
+      + type : Type
+    }
+
+    object(EventParameter) {
+      + name : String
+      + type : Type
+      + indexed : Boolean
+    }
+
+    enum(StateMutability) {
+      + pure
+      + view
+      + nonpayable
+      + payable
+    }
+
+    ConstructorInterface *-- "n" Parameter
+    ConstructorInterface *-- "1" StateMutability
+
+    FallbackInterface *-- "1" StateMutability
+
+    FunctionInterface *-- "n" Parameter
+    FunctionInterface *-- "1" StateMutability
+
+    EventInterface *-- "n" EventParameter
+  !endif
 !endif
 
 !ifdef SHOW_CONSTRUCTOR
-  !define SHOW_LINK_VALUE
+  !define SHOW_LINKED_BYTECODE
 
   resource(ContractConstructor) {
-    + name : String
-    + compilation : Compilation
+    + contract : Maybe<Contract>
     + createBytecode : LinkedBytecode
   }
 !endif
@@ -57,22 +121,24 @@
     + linkReferences : Set<LinkReference>
   }
 
-  object(Instruction) {
-    + programCounter: String
-    + opcode: Integer
-    + pushData: String
-    + meta: InstructionMeta
-  }
+  !ifdef SHOW_SOURCE_MAP || SHOW_BYTECODE_INTERNAL
+    object(Instruction) {
+      + programCounter: String
+      + opcode: Integer
+      + pushData: String
+      + meta: InstructionMeta
+    }
 
-  object(InstructionMeta) {
-    + cost: Integer
-    + pops: Integer
-    + pushes: Integer
-    + dynamic: Integer
-  }
+    object(InstructionMeta) {
+      + cost: Integer
+      + pops: Integer
+      + pushes: Integer
+      + dynamic: Integer
+    }
 
-  Instruction *-- "1" InstructionMeta
-  Bytecode *-- "n" Instruction
+    Instruction *-- "1" InstructionMeta
+    Bytecode *-- "n" Instruction
+  !endif
 !endif
 
 !ifdef SHOW_SOURCE
@@ -90,6 +156,7 @@
   resource(Compilation) {
     + compiler : Compiler
     + sources : Array<Maybe<Source>>
+    + contracts : Array<SourceContract>
   }
 
   object(Compiler) {
@@ -98,28 +165,9 @@
     + settings : Object
   }
 
-  Compiler "1" --* Compilation
-  SourceContract "n" -right-* Compilation
+  Compilation *-- "1" Compiler
+  SourceContract "n" --* Compilation
 !endif
-
-!ifdef SHOW_SOURCE_MAP
-  resource(SourceMap) {
-    + rawSourceMap : String
-    + sources : Array<Maybe<Source>>
-    + bytecode : Bytecode
-  }
-
-  object(SourceRange) {
-    + source : Source
-    + start : ByteOffset
-    + length : Length
-    + meta : Object
-  }
-
-  SourceMap *-- "n" SourceRange
-!endif
-
-
 
 !ifdef SHOW_NETWORK
   resource(Network) {
@@ -129,13 +177,16 @@
     + historicBlock: Block
   }
 
-  object(Block) {
-    + height : Integer
-    + hash : BlockHash
-  }
 
-  Network o-- "0..1" Network : <<refines>>
-  Network *-right- "1" Block
+  !ifdef SHOW_NETWORK_INTERNAL
+    object(Block) {
+      + height : Integer
+      + hash : BlockHash
+    }
+
+    Network o-- "0..1" Network : <<refines>>
+    Network *-left- "1" Block
+  !endif
 !endif
 
 
@@ -149,6 +200,8 @@
 !endif
 
 !ifdef SHOW_LINKED_BYTECODE
+  !define SHOW_LINK_VALUE
+
   object(LinkedBytecode) {
     + bytecode : Bytecode
     + linkValues : Set<LinkValue>
@@ -158,7 +211,7 @@
 !ifdef SHOW_INSTANCE_CREATION
   object(ContractInstanceCreation) {
     + transactionHash : TransactionHash
-    + contractConstructor : ContractConstructor
+    + constructor : ContractConstructor
     + constructorArgs : Array<Value>
   }
 !endif
@@ -178,10 +231,29 @@
   }
 !endif
 
+!ifdef SHOW_SOURCE_MAP
+  object(SourceMap) {
+    + rawSourceMap : String
+    + sources : Array<Maybe<Source>>
+    + bytecode : Bytecode
+  }
+
+  object(SourceRange) {
+    + source : Source
+    + start : ByteOffset
+    + length : Length
+    + meta : Object
+  }
+
+  SourceMap *-- "n" SourceRange
+!endif
+
+
 !ifdef SHOW_SOURCE_CONTRACT
   object(SourceContract) {
     + name : String
-    + compilation : Compilation
+    + source : Source
+    + ast : AST
   }
 !endif
 
@@ -202,15 +274,19 @@
 '
 
 !ifdef SHOW_CONTRACT && SHOW_ABI
-  Contract *-left- "1" ABI
+  Contract *-right- "1" ABI
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_INSTANCE
-  ContractInstance "n" o-- "1" Contract
+  ContractInstance "n" o-- "0..1" Contract
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_CONSTRUCTOR
-  ContractConstructor "1" o-- "1" Contract
+  ContractConstructor "1" o-- "0..1" Contract
+!endif
+
+!ifdef SHOW_CONTRACT && SHOW_INTERFACE
+  Contract o-- "1" ContractInterface
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_SOURCE_CONTRACT
@@ -251,7 +327,7 @@
 !endif
 
 !ifdef SHOW_COMPILATION && SHOW_SOURCE
-  Compilation o-- "n" Source
+  Compilation o-right- "n" Source
 !endif
 
 !ifdef SHOW_COMPILATION
@@ -279,18 +355,18 @@
 !endif
 
 
-
-
-!ifdef SHOW_SOURCE && SHOW_SOURCE_MAP
-  Source "n" --o SourceMap
+!ifdef SHOW_COMPILATION && SHOW_SOURCE_MAP
+  Compilation *-- "n" SourceMap
 !endif
 
-!ifdef SHOW_SOURCE && SHOW_AST
-  Source *-- "0..1" AST
+
+!ifdef SHOW_SOURCE_CONTRACT && SHOW_AST
+  SourceContract *-right- "0..1" AST
 !endif
 
 !ifdef SHOW_SOURCE_MAP && SHOW_BYTECODE
-  SourceMap .right.> "n" Instruction
+  SourceMap o-right- "1" Bytecode
+  SourceRange o-right- "1" Instruction
 !endif
 
 !ifdef SHOW_SOURCE_MAP && SHOW_SOURCE


### PR DESCRIPTION
Pardon the lazy commit, will rebase before removing draft status.

This PR:
- Starts dividing entities in the data model according to aggregate root (called "resource")
- Uses preprocessing directives to generate diagrams by subset
- Removes legend for the time being because it's out of date with these changes
- Seeks to re-organize data model nouns to more closely align with domain

[Preview](https://trufflesuite.github.io/artifact-updates/contrib/trufflesuite/data-model/data-model.html)