### PR TITLE
Update constructor

### DIFF
--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -25,6 +25,7 @@ skinparam defaultMonospacedFontName Andale Mono
     extern(Contract) {
       + name: String
       + abi: ABI
+      + constructor: Constructor
       + {method} compilation: Maybe<Compilation>
       + {method} sourceContract: Maybe<SourceContract>
       + {method} interface: ContractInterface
@@ -33,6 +34,7 @@ skinparam defaultMonospacedFontName Andale Mono
     resource(Contract) {
       + name: String
       + abi: ABI
+      + constructor: Constructor
       + {method} compilation: Maybe<Compilation>
       + {method} sourceContract: Maybe<SourceContract>
       + {method} interface: ContractInterface
@@ -134,11 +136,9 @@ skinparam defaultMonospacedFontName Andale Mono
 !ifdef SHOW_CONSTRUCTOR
   !define SHOW_LINKED_BYTECODE
 
-  resource(ContractConstructor) {
+  object(Constructor) {
     + createBytecode: LinkedBytecode
-    + {method} contract: Maybe<Contract>
     ..
-    UNKNOWN_ID
     - contractId: Maybe<ID>
   }
 !endif
@@ -285,9 +285,7 @@ skinparam defaultMonospacedFontName Andale Mono
     object(ContractInstanceCreation) {
       + transactionHash: TransactionHash
       + constructorArgs: Array<Value>
-      + {method} contractConstructor: ContractConstructor
-      ..
-      - contractConstructorId: ID
+      + {method} constructor: Constructor
     }
 !endif
 
@@ -383,7 +381,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_CONSTRUCTOR
-  ContractConstructor "1" o--- "0..1" Contract
+  Constructor "1" o--- "0..1" Contract
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_INTERFACE
@@ -422,7 +420,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !endif
 
 !ifdef SHOW_INSTANCE_CREATION && SHOW_CONSTRUCTOR
-  ContractInstanceCreation o-- "1" ContractConstructor
+  ContractInstanceCreation o-- "1" Constructor
 !endif
 
 !ifdef SHOW_INSTANCE && SHOW_LINKED_BYTECODE
@@ -430,7 +428,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !endif
 
 !ifdef SHOW_CONSTRUCTOR && SHOW_LINKED_BYTECODE
-  ContractConstructor *-- "1" LinkedBytecode
+  Constructor *-- "1" LinkedBytecode
 !endif
 
 !ifdef SHOW_COMPILATION && SHOW_COMPILER

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -379,7 +379,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_CONSTRUCTOR
-  Constructor "1" ---o "0..1" Contract
+  Constructor "0..1" ---o Contract
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_INTERFACE
@@ -418,7 +418,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !endif
 
 !ifdef SHOW_INSTANCE_CREATION && SHOW_CONSTRUCTOR
-  ContractInstanceCreation --o "1" Constructor
+  ContractInstanceCreation o-- "1" Constructor
 !endif
 
 !ifdef SHOW_INSTANCE && SHOW_LINKED_BYTECODE

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -5,6 +5,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !define hashIdField(h1) - {field} <&key> id: ID //= hash(// ""h1"" //)//
 !define hashIdField(h1,h2) - {field} <&key> id: ID //= hash(// ""h1""//,// ""h2"" //)//
 !define hashIdField(h1,h2,h3) - {field} <&key> id: ID //= hash(// ""h1""//,// ""h2""//,// ""h3"" //)//
+!define hashIdField(h1,h2,h3,h4) - {field} <&key> id: ID //= hash(// ""h1""//,// ""h2""//,// ""h3"" //,// ""h4"" //)//
 !define UNKNOWN_ID - {field} <&key> id: ID = TBD
 
 !define object(name) class name << (O,lawngreen) Data Object >>
@@ -36,7 +37,7 @@ skinparam defaultMonospacedFontName Andale Mono
       + {method} sourceContract: Maybe<SourceContract>
       + {method} interface: ContractInterface
       ..
-      UNKNOWN_ID
+      hashIdField(name,abi,sourceContract,compilation)
       - sourceContractId: TBD
     }
   !endif
@@ -53,7 +54,7 @@ skinparam defaultMonospacedFontName Andale Mono
     + callBytecode : LinkedBytecode
     + {method} contract : Maybe<Contract>
     ..
-    UNKNOWN_ID
+    hashIdField(network,address)
     - contractId: ID
   }
 

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -138,8 +138,6 @@ skinparam defaultMonospacedFontName Andale Mono
 
   object(Constructor) {
     + createBytecode: LinkedBytecode
-    ..
-    - contractId: Maybe<ID>
   }
 !endif
 
@@ -381,7 +379,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_CONSTRUCTOR
-  Constructor "1" o--- "0..1" Contract
+  Constructor "1" ---o "0..1" Contract
 !endif
 
 !ifdef SHOW_CONTRACT && SHOW_INTERFACE
@@ -420,7 +418,7 @@ skinparam defaultMonospacedFontName Andale Mono
 !endif
 
 !ifdef SHOW_INSTANCE_CREATION && SHOW_CONSTRUCTOR
-  ContractInstanceCreation o-- "1" Constructor
+  ContractInstanceCreation --o "1" Constructor
 !endif
 
 !ifdef SHOW_INSTANCE && SHOW_LINKED_BYTECODE


### PR DESCRIPTION
This PR seeks to update `ContractConstructor` with the name `Constructor` instead. Further, it demotes Constructor from a Resource to a Data Object that resides within the `Contract` Resource. For now, Constructor contains only the `createBytecode` for the contract. 

Additionally, this PR designates the components that should be hashed to determine the ID of a contract and a contractInstance. 

A contract's id should be hashed from the contract name, it's abi, the index of its sourceContract as found in the compilation, and the compilation id. 

A contract instance's id should be hashed from the network and the address fields. 