### PR TITLE
Update data model with changes to sourcemap, linkReferences, and network

### DIFF
--- a/docs/data-model.rst
+++ b/docs/data-model.rst
@@ -15,7 +15,7 @@ Projects and Named Resources
 ----------------------------
 
 Certain resources are *named*, meaning that these entities may be referenced
-by user-defined semantic identifiers. Since Truffle targets the full dev.
+by user-defined semantic identifiers. Since Truffle targets the full development
 lifecycle, this means names refer to different things at different times.
 
 |Contracts| and |Networks|, for example, both use names. These resources
@@ -65,6 +65,7 @@ Contracts, Constructors, and Instances
 
   !define SHOW_COMPILATION
   !define EXTERN_COMPILATION
+  !define SHOW_SOURCE_MAP
 
   !define SHOW_BYTECODE
   !define EXTERN_BYTECODE
@@ -95,6 +96,7 @@ Sources, Bytecodes, and Compilations
 
 Contract Interfaces
 ```````````````````
+Contract Interfaces have not been implemented in the first version of Truffle DB, but will be added in a future iteration.
 
 .. uml::
 
@@ -151,6 +153,7 @@ Combined Data Model
    !define SHOW_AST
    !define SHOW_INSTRUCTION
    !define SHOW_SOURCE_MAP
+   !define SHOW_SOURCE_RANGE
    !define SHOW_CONSTRUCTOR
 
    !include uml/macros.iuml

--- a/docs/uml/macros.iuml
+++ b/docs/uml/macros.iuml
@@ -98,7 +98,6 @@ skinparam defaultMonospacedFontName Andale Mono
       + {method} interface: ContractInterface
       ..
       hashIdField(name,abi,sourceContract,compilation)
-      - sourceContractId: TBD
       - createBytecodeId
       - callBytecodeId
     }
@@ -261,13 +260,15 @@ skinparam defaultMonospacedFontName Andale Mono
       + compiler : Compiler
       + {method} sources : Array<Maybe<Source>>
       + {method} contracts : Array<SourceContract>
+      + sourceMaps: Array<SourceMap>
       ..
     }
   !else
     resource(Compilation) {
       + compiler : Compiler
       + {method} sources : Array<Maybe<Source>>
-      + {method} contracts : Array<SourceContract>
+      + {method} contracts : Array<SourceContract>s
+      + sourceMaps: Array<SourceMap>
       ..
       hashIdField(compiler,sourceIds)
       - sourceIds: Array<Maybe<ID>>
@@ -294,7 +295,7 @@ skinparam defaultMonospacedFontName Andale Mono
       + historicBlock: Block
       + {method} fork: Maybe<Network>
       ..
-      UNKNOWN_ID
+      hashIdField(networkId,historicBlock)
       - forkId: Maybe<ID>
     }
   !endif
@@ -353,7 +354,8 @@ skinparam defaultMonospacedFontName Andale Mono
       + value: Bytes
       + {method} linkReference: LinkReference
       ..
-      - _linkReference: TBD
+      - bytecodeIds: Array<Maybe<ID>>
+      - index: Integer
     }
 !endif
 
@@ -375,14 +377,12 @@ skinparam defaultMonospacedFontName Andale Mono
 
 !ifdef SHOW_SOURCE_MAP
     object(SourceMap) {
-      + {method} bytecode: Bytecode
-      + instructionSourceRanges(index: Integer): Maybe<SourceRange>
-      ..
-      - rawSourceMap: String
-      - bytecodeId: ID
+      + json: String
     }
+!endif
 
-    object(SourceRange) {
+!ifdef SHOW_SOURCE_RANGE
+  object(SourceRange) {
       + start: ByteOffset
       + length: Length
       + meta: Object
@@ -390,8 +390,6 @@ skinparam defaultMonospacedFontName Andale Mono
       ..
       - sourceId: ID
     }
-
-    SourceMap *-right- "n" SourceRange
 !endif
 
 !ifdef SHOW_SOURCE_CONTRACT
@@ -510,7 +508,7 @@ skinparam defaultMonospacedFontName Andale Mono
 
 
 !ifdef SHOW_COMPILATION && SHOW_SOURCE_MAP
-  Compilation *-- "n" SourceMap
+  Compilation *-- "0..1" SourceMap
 !endif
 
 
@@ -518,12 +516,11 @@ skinparam defaultMonospacedFontName Andale Mono
   SourceContract *-left- "0..1" AST
 !endif
 
-!ifdef SHOW_SOURCE_MAP && SHOW_BYTECODE
-  SourceMap o---- "1" Bytecode
+!ifdef SHOW_SOURCE_RANGE && SHOW_BYTECODE
   SourceRange o-- "1" Instruction
 !endif
 
-!ifdef SHOW_SOURCE_MAP && SHOW_SOURCE
+!ifdef SHOW_SOURCE_RANGE && SHOW_SOURCE
   Source "1" --o SourceRange
 !endif
 


### PR DESCRIPTION
This PR updates the data model to reflect the code that is in the truffle-db branch, primarily with changes to reflect the new SourceMap code. 